### PR TITLE
add more constructors for Range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libsemverator"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -190,7 +190,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "semverator"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semverator"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "../README.md"
@@ -13,7 +13,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.97"
 clap = { version = '4.5.34', features = ['cargo'] }
-libsemverator = { path = "../lib", version = "0.9.1" }
+libsemverator = { path = "../lib", version = "0.10.0" }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsemverator"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "../README.md"

--- a/lib/src/range/parse.rs
+++ b/lib/src/range/parse.rs
@@ -39,6 +39,46 @@ impl Range {
         }
         Ok(Self { raw, set })
     }
+
+    pub fn any() -> Self {
+        Self {
+            raw: "*".to_string(),
+            set: vec![Constraint::Any],
+        }
+    }
+
+    pub fn single(v: &str) -> Result<Self> {
+        let raw = format!("={}", v);
+        let set = vec![Constraint::Single(
+            Semver::parse(v).context("invalid version")?,
+        )];
+        Ok(Self { raw, set })
+    }
+
+    pub fn contiguous(v1: &str, v2: &str) -> Result<Self> {
+        let raw = format!(">={}<{}", v1, v2);
+        let set = vec![Constraint::Contiguous(
+            Semver::parse(v1).context("invalid version")?,
+            Semver::parse(v2).context("invalid version")?,
+        )];
+        Ok(Self { raw, set })
+    }
+
+    pub fn caret(v: &str) -> Result<Self> {
+        let raw = format!("^{}", v);
+        let set = vec![Constraint::parse(&raw)?];
+        Ok(Self { raw, set })
+    }
+
+    pub fn tilde(v: &str) -> Result<Self> {
+        let raw = format!("~{}", v);
+        let set = vec![Constraint::parse(&raw)?];
+        Ok(Self { raw, set })
+    }
+
+    pub fn from_semver(v: &Semver) -> Result<Self> {
+        Self::single(&v.raw)
+    }
 }
 
 impl Constraint {

--- a/lib/src/tests/range.rs
+++ b/lib/src/tests/range.rs
@@ -281,6 +281,41 @@ fn test_display() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_constructors() -> Result<()> {
+    let ra = Range::parse("*")?;
+    let rb = Range::any();
+
+    assert_eq!(ra.raw, rb.raw);
+
+    let rc = Range::parse("=1.2.3")?;
+    let rd = Range::single("1.2.3")?;
+
+    assert_eq!(rc.raw, rd.raw);
+
+    let re = Range::parse(">=1.2.3<2.0.0")?;
+    let rf = Range::contiguous("1.2.3", "2.0.0")?;
+
+    assert_eq!(re.raw, rf.raw);
+
+    let rg = Range::parse("^1.2.3")?;
+    let rh = Range::caret("1.2.3")?;
+
+    assert_eq!(rg.raw, rh.raw);
+
+    let ri = Range::parse("~1.2.3")?;
+    let rj = Range::tilde("1.2.3")?;
+
+    assert_eq!(ri.raw, rj.raw);
+
+    let sa = Semver::parse("1.2.3")?;
+    let rk = Range::from_semver(&sa)?;
+
+    assert_eq!(rd.raw, rk.raw);
+
+    Ok(())
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn test_serde() -> Result<()> {


### PR DESCRIPTION
Adds:
- Range::any()
- Range::single(&str)
- Range::contiguous(&str, &str)
- Range::caret(&str)
- Range::tilde(&str)
- Range::from_semver(&Semver) // calls ::single(&str)

closes #37
