### PR TITLE
fix for pkgx issue #1190

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/target
 coverage/
+.idea
+.envrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libsemverator"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -190,7 +190,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "semverator"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semverator"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "../README.md"
@@ -13,7 +13,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = '4.5.40', features = ['cargo'] }
-libsemverator = { path = "../lib", version = "0.10.0" }
+libsemverator = { path = "../lib", version = "0.10.1" }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsemverator"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "../README.md"

--- a/lib/src/tests/range.rs
+++ b/lib/src/tests/range.rs
@@ -210,6 +210,18 @@ fn test_intersect() -> Result<()> {
     assert!(il.is_ok());
     assert_eq!(il?.raw, rg.raw);
 
+    // This is the test for https://github.com/pkgxdev/pkgx/issues/1190
+    let rn = Range::any();
+    let ro = Range::parse(">=5.0.0<Infinity.Infinity.Infinity")?;
+
+    let im = rn.intersect(&ro);
+    assert!(im.is_ok());
+    assert_eq!(im?.raw, ro.raw);
+
+    let r#in = ro.intersect(&rn);
+    assert!(r#in.is_ok());
+    assert_eq!(r#in?.raw, ro.raw);
+
     Ok(())
 }
 
@@ -277,6 +289,10 @@ fn test_display() -> Result<()> {
     assert_eq!(rh.to_string(), "~0.1.1");
     assert_eq!(ri.to_string(), ">=0.1.1");
     assert_eq!(rj.to_string(), ">=0.1.1<3");
+
+    // This is the test for https://github.com/pkgxdev/pkgx/issues/1190
+    let rk = Range::parse(">=5.0.0<Infinity.Infinity.Infinity")?;
+    assert_eq!(rk.to_string(), ">=5");
 
     Ok(())
 }


### PR DESCRIPTION
ref: https://github.com/pkgxdev/pkgx/issues/1190

certain intersection orders were creating ranges with `raw` like: `>=5.0.0<Infinity.Infinity.Infinity`. This accepts that nomenclature sanely.