### PR TITLE
ci: bump homebrew-tap formula on release

### DIFF
--- a/.github/workflows/homebrew-bump.yaml
+++ b/.github/workflows/homebrew-bump.yaml
@@ -1,0 +1,27 @@
+name: Bump Homebrew formula
+
+on:
+  release:
+    types: [published]
+
+# The bump runs against jhheider/homebrew-tap using HOMEBREW_TAP_TOKEN
+# (a personal access token with `public_repo` + `workflow` scopes), not the
+# default GITHUB_TOKEN, which cannot push to another repository.
+permissions:
+  contents: read
+
+jobs:
+  homebrew-bump:
+    name: Bump jhheider/homebrew-tap
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      - name: Open bump PR on the tap
+        uses: dawidd6/action-homebrew-bump-formula@v8
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          tap: jhheider/homebrew-tap
+          formula: semverator
+          tag: ${{ github.event.release.tag_name }}
+          no_fork: true
+          force: false


### PR DESCRIPTION
Adds a release-triggered workflow that opens a version-bump PR against [`jhheider/homebrew-tap`](https://github.com/jhheider/homebrew-tap) whenever a (non-prerelease) GitHub release is published here.

## How it works

- Fires on `release: published`, skipping prereleases.
- Uses [`dawidd6/action-homebrew-bump-formula@v8`](https://github.com/dawidd6/action-homebrew-bump-formula) to update `semverator.rb` in the tap to the new tag (URL + sha256) and open a PR there.
- `no_fork: true` — commits the bump branch directly in the tap (no fork), since the tap is owned by the same account.

## Required setup (one-time)

Create a **`HOMEBREW_TAP_TOKEN`** repository secret containing a personal access token with `public_repo` + `workflow` scopes (a classic PAT, or a fine-grained token with Contents + Pull requests write on `jhheider/homebrew-tap`). The default `GITHUB_TOKEN` can't push to another repo, so this is needed.

Until the secret exists the job runs but fails at the bump step; no releases are otherwise affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0182kFRmNxZcUDdhoDnfn95a)_