### PR TITLE
ci: publish release binaries, cut CI minutes, document install methods

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -1,15 +1,22 @@
 # https://github.com/BamPeers/rust-ci-github-actions-workflow
 
+name: Check and Lint
+
 on:
   pull_request:
+    paths-ignore: ["**.md", "LICENSE*", ".gitignore", ".markdownlint.yml"]
   push:
     branches:
       - main
+    paths-ignore: ["**.md", "LICENSE*", ".gitignore", ".markdownlint.yml"]
 
+# Cancel a superseded in-progress run when a new commit lands on the same ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-name: Check and Lint
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   check:
@@ -18,7 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo check --all-features
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --workspace --all-features
         env:
           RUSTFLAGS: "-D warnings"
 
@@ -28,7 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
-      - run: rustup component add rustfmt
+        with:
+          components: rustfmt
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -39,14 +48,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
-      - run: cargo clippy --all-features
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: "-D warnings"
-
-  markdownlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: nosborn/github-action-markdown-cli@v3.5.0
-        with:
-          files: .

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,0 +1,25 @@
+name: Markdown Lint
+
+# Split out of check-and-lint so it only runs when Markdown actually changes
+# (and, conversely, so code-only changes skip it).
+on:
+  pull_request:
+    paths: ["**.md"]
+  push:
+    branches:
+      - main
+    paths: ["**.md"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: nosborn/github-action-markdown-cli@v3.5.0
+        with:
+          files: .

--- a/.github/workflows/release-packaging.yaml
+++ b/.github/workflows/release-packaging.yaml
@@ -1,35 +1,92 @@
 # https://github.com/BamPeers/rust-ci-github-actions-workflow
 
+name: Release Packaging
+
+# Fires when a GitHub Release is published (the version must already be
+# committed in Cargo.toml). Builds the platform binaries, attaches them to the
+# release, and publishes the workspace crates to crates.io.
 on:
   release:
     types: [published]
 
-name: Release Packaging
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
-  release:
-    name: Release Packaging
-    env:
-      PROJECT_NAME_UNDERSCORE: semverator
-      RUSTFLAGS: "-D warnings"
-    runs-on: ubuntu-latest
+  build:
+    name: Build (${{ matrix.asset_name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset_name: semverator-linux-x86_64.tar.gz
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            asset_name: semverator-linux-aarch64.tar.gz
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            asset_name: semverator-macos-x86_64.tar.gz
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset_name: semverator-macos-aarch64.tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset_name: semverator-windows-x86_64.zip
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
-      - name: Release Build
-        run: cargo build -p semverator --release
-      - name: "Upload Artifact"
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.PROJECT_NAME_UNDERSCORE }}
-          path: target/release/${{ env.PROJECT_NAME_UNDERSCORE }}
 
-  publish:
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      # Cross linker for the non-native linux-aarch64 build
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        with:
+          target: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release -p semverator --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          if [[ "${{ matrix.asset_name }}" == *.zip ]]; then
+            7z a "$GITHUB_WORKSPACE/${{ matrix.asset_name }}" semverator.exe
+          else
+            tar czf "$GITHUB_WORKSPACE/${{ matrix.asset_name }}" semverator
+          fi
+
+      - name: Attach to release
+        shell: bash
+        run: gh release upload '${{ github.event.release.tag_name }}' '${{ matrix.asset_name }}' --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  publish-crates:
     name: Publish to crates.io
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Publishes workspace crates in dependency order (libsemverator, then
+      # semverator), waiting for the index between them.
       - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,22 @@
 # https://github.com/BamPeers/rust-ci-github-actions-workflow
 
+name: Test with Code Coverage
+
 on:
   pull_request:
+    paths-ignore: ["**.md", "LICENSE*", ".gitignore", ".markdownlint.yml"]
   push:
     branches:
       - main
+    paths-ignore: ["**.md", "LICENSE*", ".gitignore", ".markdownlint.yml"]
 
-name: Test with Code Coverage
-
+# Cancel a superseded in-progress run when a new commit lands on the same ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
 
 permissions:
   contents: read
@@ -25,39 +32,33 @@ jobs:
           - macos-latest
           - windows-latest
     name: Test (${{ matrix.os }})
-    env:
-      PROJECT_NAME_UNDERSCORE: semverator
-      CARGO_INCREMENTAL: 0
-      RUSTFLAGS: -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -D warnings
-      RUSTDOCFLAGS: -Cpanic=abort
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        env:
-          cache-name: cache-dependencies
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            target
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ matrix.os }}
       - name: Test
-        run: cargo test --all-features
+        run: cargo test --workspace --all-features
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage
       - name: Setup just
         uses: extractions/setup-just@v4
-      - run: cargo install cargo-tarpaulin
+      # Prebuilt binary instead of `cargo install cargo-tarpaulin`, which
+      # compiles the tool from source on every run.
+      - name: Install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
       - name: Generate test result and coverage report
         run: just coverage
       - uses: coverallsapp/github-action@v2

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ for command-line usage.
 
 ## Install
 
-`cargo install semverator` or, for [pkgx](https://pkgx.dev) users,
-`pkgx +crates.io/semverator`.
+`semverator` is available four ways:
+
+- **Homebrew:** `brew install jhheider/tap/semverator`
+- **Cargo:** `cargo install semverator`
+- **pkgx:** `pkgx +crates.io/semverator`
+- **Source:** `cargo install --path cli`
 
 ## Usage
 


### PR DESCRIPTION
## Release binaries

`Release Packaging` now cross-builds `semverator` on release publish and attaches the artifacts to the release (matching gpg-inspector's asset naming), then publishes the crates:

| Platform | Asset |
|----------|-------|
| Linux x86_64 | `semverator-linux-x86_64.tar.gz` |
| Linux aarch64 | `semverator-linux-aarch64.tar.gz` |
| macOS x86_64 | `semverator-macos-x86_64.tar.gz` |
| macOS Apple Silicon | `semverator-macos-aarch64.tar.gz` |
| Windows x86_64 | `semverator-windows-x86_64.zip` |

Previously the workflow only uploaded a single native binary as a CI artifact (not attached to the release). `publish-crates` now `needs: build`, so a broken build blocks the crates.io publish.

## CI-minute reductions (`check-and-lint`, `test`)

- **`cancel-in-progress` concurrency** — superseded runs stop immediately instead of running to completion.
- **`paths-ignore` for docs** — code CI skips Markdown-only changes; `markdownlint` moved to its own workflow that runs *only* on `**.md`.
- **`Swatinem/rust-cache`** — avoids recompiling dependencies from scratch each run.
- **Dropped the `-Ccodegen-units=1 -Copt-level=0 -Cpanic=abort …` test `RUSTFLAGS`** — these slowed compilation with no test value (they were coverage-oriented flags).
- **Coverage installs `cargo-tarpaulin` as a prebuilt binary** via `taiki-e/install-action` instead of compiling it from source on every run.

## Docs

README now lists all four install paths: Homebrew (`jhheider/tap`), Cargo, pkgx, and source.

Toolchain channel is unchanged (nightly) for the existing CI jobs; the new release build uses stable, which is standard for shipping artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0182kFRmNxZcUDdhoDnfn95a)_