### PR TITLE
libsemverator: thiserror error type + workspace hygiene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libsemverator"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -128,6 +128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "thiserror",
 ]
 
 [[package]]
@@ -264,6 +265,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,22 @@
 [workspace]
 members = ["cli", "lib"]
 resolver = "2"
+
+# Shared, non-version metadata. Versions are per-crate (see each crate's
+# Cargo.toml) so crates can be released independently.
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/jhheider/semverator"
+homepage = "https://github.com/jhheider/semverator"
+keywords = ["semver", "semantic", "versioning", "pkgx"]
+
+[workspace.dependencies]
+thiserror = "2"
+anyhow = "1.0.102"
+regex = "1.12.3"
+lazy_static = "1.5.0"
+serde = { version = "1.0.228" }
+serde_json = { version = "1.0.150" }
+clap = { version = "4.6.1", features = ["cargo"] }
+serde_test = "1.0.177"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "semverator"
 version = "0.10.1"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+license.workspace = true
 readme = "../README.md"
 description = "A command line tool for working with semantic versioning (libpkgx implementation)"
-homepage = "https://github.com/jhheider/semverator"
-repository = "https://github.com/jhheider/semverator"
-keywords = ["semver", "semantic", "versioning", "pkgx"]
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
 categories = ["command-line-utilities"]
 
 [dependencies]
-anyhow = "1.0.102"
-clap = { version = '4.6.1', features = ['cargo'] }
-libsemverator = { path = "../lib", version = "0.10.1" }
+anyhow = { workspace = true }
+clap = { workspace = true }
+libsemverator = { path = "../lib", version = "0.10.2" }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "libsemverator"
-version = "0.10.1"
-edition = "2021"
-license = "Apache-2.0"
+version = "0.10.2"
+edition.workspace = true
+license.workspace = true
 readme = "../README.md"
 description = "A library for working with semantic versioning (libpkgx implementation)"
-homepage = "https://github.com/jhheider/semverator"
-repository = "https://github.com/jhheider/semverator"
-keywords = ["semver", "semantic", "versioning", "pkgx"]
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
 categories = ["command-line-utilities"]
 
 [features]
@@ -17,14 +17,15 @@ serde = ["dep:serde", "dep:serde_json"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = "1.0.102"
-lazy_static = "1.5.0"
-regex = "1.12.3"
-serde = { version = "1.0.228", optional = true }
-serde_json = { version = "1.0.150", optional = true }
+lazy_static = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [dev-dependencies]
-serde_test = "1.0.177"
+serde_test = { workspace = true }
+anyhow = { workspace = true }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+/// Errors from parsing and manipulating semantic versions and ranges.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum Error {
+    #[error("invalid semver: {0}")]
+    Semver(String),
+    #[error("invalid range: {0}")]
+    Range(String),
+}
+
+/// Convenience alias for results returning [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,8 @@
+mod error;
 pub mod range;
 pub mod semver;
+
+pub use error::{Error, Result};
 
 #[cfg(test)]
 mod tests;

--- a/lib/src/range/intersect.rs
+++ b/lib/src/range/intersect.rs
@@ -1,5 +1,5 @@
 use super::{Constraint, Range};
-use anyhow::{bail, Result};
+use crate::error::{Error, Result};
 
 impl Range {
     pub fn intersect(&self, range: &Range) -> Result<Range> {
@@ -39,7 +39,7 @@ impl Range {
             }
         }
         if set.is_empty() {
-            bail!("no intersection possible")
+            return Err(Error::Range("no intersection possible".into()));
         }
         let mut rv = Range {
             raw: "".to_string(),

--- a/lib/src/range/parse.rs
+++ b/lib/src/range/parse.rs
@@ -1,7 +1,7 @@
 use crate::semver::Semver;
 
 use super::{Constraint, Range};
-use anyhow::{bail, Context, Result};
+use crate::error::{Error, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -25,7 +25,7 @@ impl Range {
         let mut set = Vec::new();
 
         if range.is_empty() {
-            bail!("no constraints")
+            return Err(Error::Range("no constraints".into()));
         }
 
         if range == "*" {
@@ -40,7 +40,10 @@ impl Range {
         for c in set.iter() {
             if let Constraint::Contiguous(v1, v2) = c {
                 if !v1.lt(v2) {
-                    bail!("{} is greater than {}", v1.raw, v2.raw)
+                    return Err(Error::Range(format!(
+                        "{} is greater than {}",
+                        v1.raw, v2.raw
+                    )));
                 }
             }
         }
@@ -56,17 +59,15 @@ impl Range {
 
     pub fn single(v: &str) -> Result<Self> {
         let raw = format!("={v}");
-        let set = vec![Constraint::Single(
-            Semver::parse(v).context("invalid version")?,
-        )];
+        let set = vec![Constraint::Single(Semver::parse(v)?)];
         Ok(Self { raw, set })
     }
 
     pub fn contiguous(v1: &str, v2: &str) -> Result<Self> {
         let raw = format!(">={v1}<{v2}");
         let set = vec![Constraint::Contiguous(
-            Semver::parse(v1).context("invalid version")?,
-            Semver::parse(v2).context("invalid version")?,
+            Semver::parse(v1)?,
+            Semver::parse(v2)?,
         )];
         Ok(Self { raw, set })
     }
@@ -91,9 +92,17 @@ impl Range {
 impl Constraint {
     pub fn parse(constraint: &str) -> Result<Self> {
         if let Some(cap) = CONSTRAINT_REGEX_RANGE.captures(constraint) {
-            let v1 = Semver::parse(cap.get(1).context("invalid description")?.as_str())?;
+            let v1 = Semver::parse(
+                cap.get(1)
+                    .ok_or_else(|| Error::Range("invalid description".into()))?
+                    .as_str(),
+            )?;
             let v2 = if cap.get(3).is_some() {
-                Semver::parse(cap.get(4).context("invalid description")?.as_str())?
+                Semver::parse(
+                    cap.get(4)
+                        .ok_or_else(|| Error::Range("invalid description".into()))?
+                        .as_str(),
+                )?
             } else {
                 Semver::infinty()
             };
@@ -110,9 +119,17 @@ impl Constraint {
         }
 
         if let Some(cap) = CONSTRAINT_REGEX_SIMPLE.captures(constraint) {
-            return match cap.get(1).context("invalid character")?.as_str() {
+            return match cap
+                .get(1)
+                .ok_or_else(|| Error::Range("invalid character".into()))?
+                .as_str()
+            {
                 "^" => {
-                    let v1 = Semver::parse(cap.get(2).context("invalid description")?.as_str())?;
+                    let v1 = Semver::parse(
+                        cap.get(2)
+                            .ok_or_else(|| Error::Range("invalid description".into()))?
+                            .as_str(),
+                    )?;
                     if v1.major > 0 {
                         let v2 = Semver::parse(&format!("{}", v1.major + 1))?;
                         return Ok(Constraint::Contiguous(v1, v2));
@@ -124,7 +141,11 @@ impl Constraint {
                     }
                 }
                 "~" => {
-                    let v1 = Semver::parse(cap.get(2).context("invalid description")?.as_str())?;
+                    let v1 = Semver::parse(
+                        cap.get(2)
+                            .ok_or_else(|| Error::Range("invalid description".into()))?
+                            .as_str(),
+                    )?;
 
                     let v2 = if v1.components.len() == 1 {
                         Semver::parse(&format!("{}", v1.major + 1))?
@@ -135,13 +156,23 @@ impl Constraint {
                 }
                 "<" => {
                     let v1 = Semver::parse("0")?;
-                    let v2 = Semver::parse(cap.get(2).context("invalid description")?.as_str())?;
+                    let v2 = Semver::parse(
+                        cap.get(2)
+                            .ok_or_else(|| Error::Range("invalid description".into()))?
+                            .as_str(),
+                    )?;
                     Ok(Constraint::Contiguous(v1, v2))
                 }
                 "@" => {
-                    let v1 = Semver::parse(cap.get(2).context("invalid description")?.as_str())?;
+                    let v1 = Semver::parse(
+                        cap.get(2)
+                            .ok_or_else(|| Error::Range("invalid description".into()))?
+                            .as_str(),
+                    )?;
                     let mut parts = v1.components.clone();
-                    let last = parts.last_mut().context("version too short")?;
+                    let last = parts
+                        .last_mut()
+                        .ok_or_else(|| Error::Range("version too short".into()))?;
                     *last += 1;
                     let v2 = Semver::parse(
                         &parts
@@ -153,11 +184,16 @@ impl Constraint {
                     Ok(Constraint::Contiguous(v1, v2))
                 }
                 "=" => Ok(Constraint::Single(Semver::parse(
-                    cap.get(2).context("invalid description")?.as_str(),
+                    cap.get(2)
+                        .ok_or_else(|| Error::Range("invalid description".into()))?
+                        .as_str(),
                 )?)),
                 _ => unreachable!("invalid range description: {}", constraint),
             };
         }
-        bail!("invalid range description: {}", constraint)
+        Err(Error::Range(format!(
+            "invalid range description: {}",
+            constraint
+        )))
     }
 }

--- a/lib/src/semver/bump.rs
+++ b/lib/src/semver/bump.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use crate::error::{Error, Result};
 
 use super::Semver;
 
@@ -27,7 +27,7 @@ impl SemverComponent {
             "major" => Ok(Self::Major),
             "minor" => Ok(Self::Minor),
             "patch" => Ok(Self::Patch),
-            _ => bail!("invalid bump component '{}'", s),
+            _ => Err(Error::Semver(format!("invalid bump component '{}'", s))),
         }
     }
 }

--- a/lib/src/semver/parse.rs
+++ b/lib/src/semver/parse.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::error::{Error, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -15,24 +15,36 @@ impl Semver {
     pub fn parse(semver: &str) -> Result<Self> {
         let raw = semver.trim_start_matches('v').to_string();
 
-        let captures = FULL_REGEX.captures(&raw).context("invalid semver")?;
+        let captures = FULL_REGEX
+            .captures(&raw)
+            .ok_or_else(|| Error::Semver("invalid semver".into()))?;
 
         let mut components: Vec<usize> = captures
             .get(1)
-            .context("regex failure")?
+            .ok_or_else(|| Error::Semver("regex failure".into()))?
             .as_str()
             .split('.')
-            .map(|s| s.parse::<usize>().context("invalid digit"))
+            .map(|s| {
+                s.parse::<usize>()
+                    .map_err(|_| Error::Semver("invalid digit".into()))
+            })
             .collect::<Result<Vec<usize>>>()?;
 
         if let Some(letter) = captures.get(2) {
-            let letter = letter.as_str().chars().next().context("not a character")? as usize
+            let letter = letter
+                .as_str()
+                .chars()
+                .next()
+                .ok_or_else(|| Error::Semver("not a character".into()))?
+                as usize
                 - 'a' as usize
                 + 1;
             components.push(letter);
         }
 
-        let major = *components.first().context("string is too short")?;
+        let major = *components
+            .first()
+            .ok_or_else(|| Error::Semver("string is too short".into()))?;
         let minor = *components.get(1).unwrap_or(&0);
         let patch = *components.get(2).unwrap_or(&0);
 


### PR DESCRIPTION
Converts `libsemverator` from `anyhow` to a typed `thiserror` error, per the lib/bin convention (libs use thiserror, bins use anyhow/eyre), and hoists shared workspace metadata/deps.

## Error type
- New `lib/src/error.rs`: a String-based `Error` enum with `Semver(String)` / `Range(String)` variants plus a `Result<T>` alias, re-exported from the crate root.
- The enum is intentionally `String`-based so it is `Send + Sync + 'static`, which keeps anyhow's blanket `From` working for downstream consumers.
- Every anyhow site in `semver/*` maps to `Error::Semver`, every site in `range/*` maps to `Error::Range`. `.context(..)` on `Option`s becomes `.ok_or_else(..)`, `bail!` becomes `return Err(..)`, and redundant `.context("invalid version")` on `Semver::parse` results is dropped (the Semver error already propagates).
- `anyhow` moves to `[dev-dependencies]` in lib (the tests use `anyhow::Result`, which keeps compiling because the crate `Error` converts into anyhow via `?`).

## Workspace hygiene
- Root `Cargo.toml` gains `[workspace.package]` (shared non-version metadata: edition, license, repository, homepage, keywords) and `[workspace.dependencies]` (thiserror, anyhow, regex, lazy_static, serde, serde_json, clap, serde_test), matching how edikt/penknife are structured.
- `lib`/`cli` inherit shared metadata via `field.workspace = true` and deps via `{ workspace = true }`. Per-crate `version` literals stay decoupled (lib = 0.10.2, cli = 0.10.1); `version.workspace` is deliberately not used.

## Versioning
This is **libsemverator 0.10.2**, a non-breaking patch (non-boundary): pkgx's call sites use `?`/map/`Ok`-match with no error downcast, so they keep compiling. cli's own version stays at 0.10.1 (lib and cli version independently); its dep pin is bumped to 0.10.2.

## Validation
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo test --workspace`: 16 tests green

## pkgx safety check (primary consumer)
Pointed a local pkgx clone's `libpkgx` (which depends on `libsemverator = "0.10.1", features = ["serde"]`) at this branch's `lib` via a path override and ran:

```
cargo check -p libpkgx
# ... Checking libsemverator v0.10.2 (path: this branch) ...
# Finished `dev` profile
# exit 0
```

libpkgx compiles clean against 0.10.2. The pkgx clone was not modified (override reverted, no commits there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtgaNLj8kZthZWZBr9kMyh